### PR TITLE
Ports binding

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     image: syspass/syspass:3.1.2
     restart: always
     ports:
-      - "80"
-      - "443"
+      - "80:80"
+      - "443:443"
     links:
       - db
     volumes:


### PR DESCRIPTION
Suggesting to change either docker-compose.yml or documentation https://syspass-doc.readthedocs.io/en/3.1/installing/docker.html#id2, because this configuration doesn't bind 80 or 443 to outside but random port.

[root@syspass-docker ~]# docker ps -a
CONTAINER ID        IMAGE                   COMMAND                  CREATED             STATUS              PORTS                                           NAMES
a25de533af49        syspass/syspass:3.1.2   "/usr/local/sbin/ent…"   3 minutes ago       Up 3 minutes        0.0.0.0:32770->80/tcp, 0.0.0.0:32769->443/tcp   syspass-app
2a8a0a0c17a9        mariadb:10.2            "docker-entrypoint.s…"   3 minutes ago       Up 3 minutes        0.0.0.0:32768->3306/tcp                         syspass-db

[root@syspass-docker ~]# netstat -tulpn
Active Internet connections (only servers)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      1075/sshd
tcp        0      0 127.0.0.1:25            0.0.0.0:*               LISTEN      1455/master
tcp6       0      0 :::22                   :::*                    LISTEN      1075/sshd
tcp6       0      0 ::1:25                  :::*                    LISTEN      1455/master
tcp6       0      0 :::32768                :::*                    LISTEN      3636/docker-proxy
tcp6       0      0 :::32769                :::*                    LISTEN      3725/docker-proxy
tcp6       0      0 :::32770                :::*                    LISTEN      3736/docker-proxy
udp        0      0 0.0.0.0:68              0.0.0.0:*                           818/dhclient
udp        0      0 127.0.0.1:323           0.0.0.0:*                           739/chronyd
udp6       0      0 ::1:323                 :::*                                739/chronyd